### PR TITLE
Update router.js

### DIFF
--- a/lib/web/articles/router.js
+++ b/lib/web/articles/router.js
@@ -24,7 +24,7 @@ module.exports = function articlesRouter(app) {
 
   function listArticles(req, res, next) {
     app
-      .listArticles(req.user.id, 15, req.param('fresh'))
+      .listArticles(req.user.id, 15, req.params.fresh)
       .then(sendList, next);
 
     function sendList(list) {


### PR DESCRIPTION
Change to remove the Express.js deprecated use warning in the console. Resolves issue #13